### PR TITLE
deps: Updatecli version used by GitHub action

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,3 +1,4 @@
+---
 name: Updatecli
 on:
   release:
@@ -14,7 +15,7 @@ jobs:
       - name: "Setup updatecli"
         uses: "updatecli/updatecli-action@4b17f4ea784de29f71f85f9bc4955402ba1ae53c" # v2.100.0
         with:
-          version: "v0.113.0"
+          version: "v0.115.0"
       - name: "Set up Go"
         uses: "actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417" # v6.3.0
         with:

--- a/.github/workflows/updatecli_test.yaml
+++ b/.github/workflows/updatecli_test.yaml
@@ -1,3 +1,4 @@
+---
 name: Updatecli Test
 on:
   pull_request:
@@ -12,7 +13,7 @@ jobs:
       - name: "Setup updatecli"
         uses: "updatecli/updatecli-action@4b17f4ea784de29f71f85f9bc4955402ba1ae53c" # v2.100.0
         with:
-          version: "v0.113.0"
+          version: "v0.115.0"
       - name: "Set up Go"
         uses: "actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417" # v6.3.0
         with:

--- a/.github/workflows/updatecli_update.yaml
+++ b/.github/workflows/updatecli_update.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: "Setup updatecli"
         uses: "updatecli/updatecli-action@4b17f4ea784de29f71f85f9bc4955402ba1ae53c" # v2.100.0
         with:
-          version: "v0.113.0"
+          version: "v0.115.0"
       - name: "Set up Go"
         uses: "actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417" # v6.3.0
         with:


### PR DESCRIPTION



<Actions>
    <action id="827c04a014e3fa0b839dce6eed66f8be28c3d79bc333cfacfe830b786f3fd6dd">
        <h3>deps: Updatecli version used by GitHub action</h3>
        <details id="45ce759e6fff98752e317f0429d365fb823af88362545902f947ccebf85b49e3">
            <summary>deps: update Updatecli used by Github Action to v0.115.0</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.jobs.*.steps[?(@.uses =~ /^updatecli\\/updatecli-action/)].with.version&#34; updated from &#34;v0.113.0&#34; to &#34;v0.115.0&#34;, in file &#34;.github/workflows/updatecli_update.yaml&#34; (doc 0)&#xA;* key &#34;$.jobs.*.steps[?(@.uses =~ /^updatecli\\/updatecli-action/)].with.version&#34; updated from &#34;v0.113.0&#34; to &#34;v0.115.0&#34;, in file &#34;.github/workflows/updatecli.yaml&#34; (doc 0)&#xA;* key &#34;$.jobs.*.steps[?(@.uses =~ /^updatecli\\/updatecli-action/)].with.version&#34; updated from &#34;v0.113.0&#34; to &#34;v0.115.0&#34;, in file &#34;.github/workflows/updatecli_test.yaml&#34; (doc 0)</p>
            <details>
                <summary>v0.115.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat(compose): add include parameter to compose file @olblak (#8120)&#xD;&#xA;- feat(autodiscovery): by default enable gha digest @olblak (#8074)&#xD;&#xA;- fix(github): allow GitHub client creation without a token for unauthenticated access @railgun-0402 (#8054)&#xD;&#xA;- fix(file): don&#39;t output binary file content @AdeshDeshmukh (#7874)&#xD;&#xA;- feat(flux): support multiple yaml documents @olblak (#8056)&#xD;&#xA;- Dockerfile: Add ability to leave unset or empty value alone @Vlatombe (#7870)&#xD;&#xA;- feat(compose): support inline values @olblak (#7868)&#xD;&#xA;- feat(autodiscovery): align matching rule validation across all plugins @railgun-0402 (#7867)&#xD;&#xA;-  feat(tmp): add --unique-tmp-dir flag to support parallel execution @railgun-0402 (#7864)&#xD;&#xA;- feat(scm): add gitlabsearch SCM plugin @railgun-0402 (#7843)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix(json): disable HTML escaping when writing JSON files @loispostula (#8090)&#xD;&#xA;- When the Adoptium API advertises a MostRecentFeatureRelease (e.g. 26) @loispostula (#8075)&#xD;&#xA;- fix(gitlabsearch): add missing depth parameter @olblak (#7934)&#xD;&#xA;- fix(githubsearch): add missing depth parameter support @olblak (#7933)&#xD;&#xA;- fix(helm): Remove validation check for helm chart name @varad-kadam (#7873)&#xD;&#xA;- fix(dockercompose): add compose*.y*ml to defaultFilePattern @qianlongzt (#7845)&#xD;&#xA;- fix(autodiscovery/argocd): correctly handle multiple documents @olblak (#7848)&#xD;&#xA;- fix(autodiscovery/kubernetes): handle multiple yaml document @olblak (#7846)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- chore: update typos action to version v1.44.0 @olblak (#8108)&#xD;&#xA;- chore: improve various gha pipeline @olblak (#8076)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.20.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#8079)&#xD;&#xA;- refactor(httpclient): centralize HTTP client creation and harden transport @loispostula (#8072)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/source-controller/api to v1.8.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#8068)&#xD;&#xA;- chore(deps): bump github.com/buger/jsonparser from 1.1.1 to 1.1.2 in the go_modules group across 1 directory @[dependabot[bot]](https://github.com/apps/dependabot) (#8070)&#xD;&#xA;- chore(deps): bump google.golang.org/grpc from 1.79.1 to 1.79.3 in the go_modules group across 1 directory @[dependabot[bot]](https://github.com/apps/dependabot) (#8036)&#xD;&#xA;- deps: Bump Golang version to 1.26.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#8002)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/helm-controller/api to v1.5.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7988)&#xD;&#xA;- install Zizmor gha action v0.5.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7986)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.289.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7976)&#xD;&#xA;- deps(go): bump module github.com/getsops/sops/v3 to v3.12.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7963)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.32.11 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7956)&#xD;&#xA;- chore(dockerfile): upgrade node version @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7819)&#xD;&#xA;- vi : github action workflow typo @olblak (#7876)&#xD;&#xA;- deps: Bump updatecli version @olblak (#7875)&#xD;&#xA;- chore(deps): bump github.com/docker/cli from 28.5.0+incompatible to 29.2.0+incompatible in the go_modules group across 1 directory @[dependabot[bot]](https://github.com/apps/dependabot) (#7869)&#xD;&#xA;- Add GitHub Actions workflow for zizmor security analysis @olblak (#7865)&#xD;&#xA;- deps(go): bump module github.com/aws/smithy-go to v1.24.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7858)&#xD;&#xA;- deps(go): bump module github.com/fluxcd/source-controller/api to v1.8.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7850)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.51.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7857)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.45.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7854)&#xD;&#xA;- deps(go): bump module github.com/go-git/go-git/v5 to v5.17.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7852)&#xD;&#xA;- deps(go): bump module github.com/drone/go-scm to v1.42.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7823)&#xD;&#xA;- chore(deps): bump go.opentelemetry.io/otel/sdk from 1.38.0 to 1.40.0 in the go_modules group across 1 directory @[dependabot[bot]](https://github.com/apps/dependabot) (#7847)&#xD;&#xA;- chore(deps): bump github.com/cloudflare/circl from 1.6.1 to 1.6.3 in the go_modules group across 1 directory @[dependabot[bot]](https://github.com/apps/dependabot) (#7842)&#xD;&#xA;- deps(go): bump module github.com/zclconf/go-cty to v1.18.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7830)&#xD;&#xA;- deps(go): bump module github.com/aws/smithy-go to v1.24.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7832)&#xD;&#xA;&#xD;&#xA;## 📝 Documentation&#xD;&#xA;&#xD;&#xA;- Update sponsorship section in release-drafter.yaml @olblak (#8121)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@AdeshDeshmukh, @Vlatombe, @dependabot[bot], @loispostula, @olblak, @qianlongzt, @railgun-0402, @updateclibot[bot], @varad-kadam, [dependabot[bot]](https://github.com/apps/dependabot) and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;&#xD;&#xA;## Sponsors&#xD;&#xA;&#xD;&#xA;If Updatecli is useful to you, please consider sponsoring it.  &#xD;&#xA;Your support helps maintain and improve this project.&#xD;&#xA;&#xD;&#xA;[![GitHub stars](https://img.shields.io/github/stars/updatecli/updatecli?style=for-the-badge)](https://github.com/updatecli/updatecli/stargazers) [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?style=for-the-badge)](https://www.updatecli.io/support/#sponsor-or-donate)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.114.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: allow to specify depth for git clone option @olblak (#7668)&#xD;&#xA;- feat(gittag): add lsremote parameter to skip git clone @olblak (#7669)&#xD;&#xA;- chore: improve error messaging in resource execution @olblak (#7691)&#xD;&#xA;- feat(autodiscovery): bazel support @josill (#7568)&#xD;&#xA;- feat(autodiscovery): add Woodpecker CI plugin @railgun-0402 (#7635)&#xD;&#xA;- feat(core): allow to filter pipeline based on labels @olblak (#7621)&#xD;&#xA;- feat(core): rename pipeline commands @josill (#7613)&#xD;&#xA;- feat(file): add templating file path @mallendem (#7591)&#xD;&#xA;- feat(gittag): add the parameter tag for gittag @josill (#7486)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- chore(jsonschema): set empty console output spec @olblak (#7818)&#xD;&#xA;- fix(autodiscovery): correctly handle wrong docker image name @olblak (#7659)&#xD;&#xA;- fix(file): file condition bug with searchpattern and matchpattern @olblak (#7619)&#xD;&#xA;- fix(file): file target bug with searchpattern and matchpattern @josill (#7629)&#xD;&#xA;- fix(autodiscovery/helmfile): error on invalid ignore spec @railgun-0402 (#7620)&#xD;&#xA;- fix(github): handle error before variable assignment @olblak (#7593)&#xD;&#xA;- fix(changelog): Add semver sorting to action changelogs @josill (#7569)&#xD;&#xA;- fix(terragrunt): add missing username for token authentication @eugenestarchenko (#7506)&#xD;&#xA;- fix: remove lowercase &#39;l&#39; from compiler flags pattern to fix -latest false positive @josill (#7485)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps: bump golang to 1.26.0 @olblak (#7817)&#xD;&#xA;- test(config): add failure-case tests for helm template functions @ak95asb (#7816)&#xD;&#xA;- chore: allow to run Updatecli daily on monitored pipeline @olblak (#7814)&#xD;&#xA;- chore(deps): bump filippo.io/edwards25519 from 1.1.0 to 1.1.1 in the go_modules group across 1 directory @[dependabot[bot]](https://github.com/apps/dependabot) (#7808)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.34.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7804)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.289.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7795)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.20.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7791)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.31.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7788)&#xD;&#xA;- chore(dockerfile): upgrade node version @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7671)&#xD;&#xA;- deps(go): bump module code.gitea.io/sdk/gitea to v0.23.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7772)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.30.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7773)&#xD;&#xA;- deps(go): bump module golang.org/x/mod to v0.33.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7776)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.50.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7768)&#xD;&#xA;- deps: bump golangci-lint to v2.9.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7754)&#xD;&#xA;- deps(go): bump module github.com/drone/go-scm to v1.41.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7736)&#xD;&#xA;- deps(go): bump module github.com/go-viper/mapstructure/v2 to v2.5.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7732)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.29.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7727)&#xD;&#xA;- deps(go): bump module golang.org/x/oauth2 to v0.35.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7730)&#xD;&#xA;- deps(go): bump module github.com/sirupsen/logrus to v1.9.4 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7734)&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.15.4 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7737)&#xD;&#xA;- deps(go): bump module github.com/jferrl/go-githubauth to v1.5.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7739)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.19.5 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7735)&#xD;&#xA;- deps(go): bump module github.com/go-git/go-git/v5 to v5.16.5 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7704)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.286.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7699)&#xD;&#xA;- deps: Bump Golang version to 1.25.7 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7674)&#xD;&#xA;- Update Updatecli cronjob @olblak (#7663)&#xD;&#xA;- fix: e2e tests related to updatecli pipeline deprecation @olblak (#7636)&#xD;&#xA;- chore(ci): Update typos action to version 1.42.0 @olblak (#7445)&#xD;&#xA;- chore: migrate gopkg.in/yaml.v3 to go.yaml.in/yaml/v3 @olblak (#7592)&#xD;&#xA;- refactor: migrate away from Golang module github.com/vmware-labs/yaml-jsonpath @ErickdelaCruzCas (#7527)&#xD;&#xA;- Add daily schedule for updatecli workflow @olblak (#7586)&#xD;&#xA;- Add jsonschema required tag to resource Name field @olblak (#7576)&#xD;&#xA;- feat: Deprecate and remove scm commit title configuration @josill (#7570)&#xD;&#xA;- deps: bump golangci-lint to v2.8.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7571)&#xD;&#xA;- deps(go): bump module golang.org/x/mod to v0.32.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7554)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.14.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7559)&#xD;&#xA;- deps(go): bump module golang.org/x/text to v0.33.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7555)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.32.7 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7551)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/credentials to v1.19.7 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7540)&#xD;&#xA;- deps(go): bump module github.com/goccy/go-yaml to v1.19.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7534)&#xD;&#xA;- fix(e2e): remove requiredEnv github_token from test @olblak (#7507)&#xD;&#xA;- deps(go): bump module gopkg.in/ini.v1 to v1.67.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7494)&#xD;&#xA;&#xD;&#xA;## 📝 Documentation&#xD;&#xA;&#xD;&#xA;- doc: improve dockerfile &amp; dockerimage plugin documentation @olblak (#7609)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@ErickdelaCruzCas, @ak95asb, @dependabot[bot], @eugenestarchenko, @josill, @mallendem, @olblak, @railgun-0402, @updateclibot[bot], [dependabot[bot]](https://github.com/apps/dependabot) and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.114.0-rc.1</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat: allow to specify depth for git clone option @olblak (#7668)&#xD;&#xA;- feat(gittag): add lsremote parameter to skip git clone @olblak (#7669)&#xD;&#xA;- chore: improve error messaging in resource execution @olblak (#7691)&#xD;&#xA;- feat(autodiscovery): bazel support @josill (#7568)&#xD;&#xA;- feat(autodiscovery): add Woodpecker CI plugin @railgun-0402 (#7635)&#xD;&#xA;- feat(core): allow to filter pipeline based on labels @olblak (#7621)&#xD;&#xA;- feat(core): rename pipeline commands @josill (#7613)&#xD;&#xA;- feat(file): add templating file path @mallendem (#7591)&#xD;&#xA;- feat(gittag): add the parameter tag for gittag @josill (#7486)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix(autodiscovery): correctly handle wrong docker image name @olblak (#7659)&#xD;&#xA;- fix(file): file condition bug with searchpattern and matchpattern @olblak (#7619)&#xD;&#xA;- fix(file): file target bug with searchpattern and matchpattern @josill (#7629)&#xD;&#xA;- fix(autodiscovery/helmfile): error on invalid ignore spec @railgun-0402 (#7620)&#xD;&#xA;- fix(github): handle error before variable assignment @olblak (#7593)&#xD;&#xA;- fix(changelog): Add semver sorting to action changelogs @josill (#7569)&#xD;&#xA;- fix(terragrunt): add missing username for token authentication @eugenestarchenko (#7506)&#xD;&#xA;- fix: remove lowercase &#39;l&#39; from compiler flags pattern to fix -latest false positive @josill (#7485)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(go): bump module code.gitea.io/sdk/gitea to v0.23.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7772)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.30.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7773)&#xD;&#xA;- deps(go): bump module golang.org/x/mod to v0.33.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7776)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.50.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7768)&#xD;&#xA;- deps: bump golangci-lint to v2.9.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7754)&#xD;&#xA;- deps(go): bump module github.com/drone/go-scm to v1.41.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7736)&#xD;&#xA;- deps(go): bump module github.com/go-viper/mapstructure/v2 to v2.5.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7732)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.29.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7727)&#xD;&#xA;- deps(go): bump module golang.org/x/oauth2 to v0.35.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7730)&#xD;&#xA;- deps(go): bump module github.com/sirupsen/logrus to v1.9.4 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7734)&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.15.4 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7737)&#xD;&#xA;- deps(go): bump module github.com/jferrl/go-githubauth to v1.5.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7739)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.19.5 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7735)&#xD;&#xA;- deps(go): bump module github.com/go-git/go-git/v5 to v5.16.5 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7704)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.286.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7699)&#xD;&#xA;- deps: Bump Golang version to 1.25.7 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7674)&#xD;&#xA;- Update Updatecli cronjob @olblak (#7663)&#xD;&#xA;- fix: e2e tests related to updatecli pipeline deprecation @olblak (#7636)&#xD;&#xA;- chore(ci): Update typos action to version 1.42.0 @olblak (#7445)&#xD;&#xA;- chore: migrate gopkg.in/yaml.v3 to go.yaml.in/yaml/v3 @olblak (#7592)&#xD;&#xA;- refactor: migrate away from Golang module github.com/vmware-labs/yaml-jsonpath @ErickdelaCruzCas (#7527)&#xD;&#xA;- Add daily schedule for updatecli workflow @olblak (#7586)&#xD;&#xA;- Add jsonschema required tag to resource Name field @olblak (#7576)&#xD;&#xA;- feat: Deprecate and remove scm commit title configuration @josill (#7570)&#xD;&#xA;- deps: bump golangci-lint to v2.8.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7571)&#xD;&#xA;- deps(go): bump module golang.org/x/mod to v0.32.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7554)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.14.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7559)&#xD;&#xA;- deps(go): bump module golang.org/x/text to v0.33.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7555)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.32.7 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7551)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/credentials to v1.19.7 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7540)&#xD;&#xA;- deps(go): bump module github.com/goccy/go-yaml to v1.19.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7534)&#xD;&#xA;- fix(e2e): remove requiredEnv github_token from test @olblak (#7507)&#xD;&#xA;- deps(go): bump module gopkg.in/ini.v1 to v1.67.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7494)&#xD;&#xA;&#xD;&#xA;## 📝 Documentation&#xD;&#xA;&#xD;&#xA;- doc: improve dockerfile &amp; dockerimage plugin documentation @olblak (#7609)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@ErickdelaCruzCas, @eugenestarchenko, @josill, @mallendem, @olblak, @railgun-0402, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>v0.113.0</summary>
                <pre>## Changes&#xD;&#xA;&#xD;&#xA;## 🚀 Features&#xD;&#xA;&#xD;&#xA;- feat(replaceAll): add replaceAll method for converting different semver conventions @josill (#7480)&#xD;&#xA;- feat(autodiscovery): propagate npm resource-level spec @loispostula (#7479)&#xD;&#xA;- feat: Add support for custom autodiscovery plugin @olblak (#7034)&#xD;&#xA;- feat(terragrunt): add GitHub authentication support @eugenestarchenko (#7359)&#xD;&#xA;- chore: revamp scaffolded policy @olblak (#7308)&#xD;&#xA;- feat: add --existing-only parameter @olblak (#7155)&#xD;&#xA;- feat: add yaml support for multi document @olblak (#6771)&#xD;&#xA;&#xD;&#xA;## 🐛 Bug Fixes&#xD;&#xA;&#xD;&#xA;- fix: autodiscovery container/helm auth @olblak (#7238)&#xD;&#xA;- fix: udash publish without config  file @olblak (#7394)&#xD;&#xA;- fix: Support valid Terragrunt tfr:/// format in autodiscovery @eugenestarchenko (#7357)&#xD;&#xA;- fix(terragrunt): strip double slash path separator from git URLs @eugenestarchenko (#7358)&#xD;&#xA;- fix(gitlab): Panic when create merge request times out @rb3ckers (#7296)&#xD;&#xA;- Fix usage of versionfilter regex kind in autodiscovery plugins @kevinleturc (#7223)&#xD;&#xA;&#xD;&#xA;## 🧰 Maintenance&#xD;&#xA;&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/service/ec2 to v1.279.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7471)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.11.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7462)&#xD;&#xA;- deps(go): bump module github.com/BurntSushi/toml to v1.6.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7464)&#xD;&#xA;- deps(go): bump module cuelang.org/go to v0.15.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7460)&#xD;&#xA;- deps(go): bump module github.com/yuin/goldmark to v1.7.16 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7450)&#xD;&#xA;- chore: Update Updatecli GHA workflow @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7444)&#xD;&#xA;- deps(go): bump module github.com/tetratelabs/wazero to v1.11.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7421)&#xD;&#xA;- deps(go): bump module github.com/yuin/goldmark to v1.7.14 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7417)&#xD;&#xA;- chore(dockerfile): upgrade node version @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7297)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/config to v1.32.6 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7401)&#xD;&#xA;- chore: publish Updatecli pipeline report to uda.sh @olblak (#7376)&#xD;&#xA;- deps(go): bump module golang.org/x/net to v0.48.0 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7343)&#xD;&#xA;- deps(go): bump module github.com/aws/aws-sdk-go-v2/credentials to v1.19.6 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7339)&#xD;&#xA;- deps(go): bump module gitlab.com/gitlab-org/api/client-go to v1.8.2 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7317)&#xD;&#xA;- deps(go): bump module helm.sh/helm/v3 to v3.19.4 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7285)&#xD;&#xA;- deps(go): bump module github.com/goccy/go-yaml to v1.19.1 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7273)&#xD;&#xA;- chore(dockerfile): upgrade node version @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7210)&#xD;&#xA;- deps(go): bump module github.com/moby/buildkit to v0.26.3 @[updateclibot[bot]](https://github.com/apps/updateclibot) (#7225)&#xD;&#xA;&#xD;&#xA;## 📝 Documentation&#xD;&#xA;&#xD;&#xA;- Update conference links in README.adoc @olblak (#7321)&#xD;&#xA;- chore: revamp scaffolded policy @olblak (#7308)&#xD;&#xA;&#xD;&#xA;## Contributors&#xD;&#xA;&#xD;&#xA;@eugenestarchenko, @josill, @kevinleturc, @loispostula, @olblak, @rb3ckers, @updateclibot[bot] and [updateclibot[bot]](https://github.com/apps/updateclibot)&#xD;&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

